### PR TITLE
[fix] add a sleep time to improve the app.destroy()

### DIFF
--- a/utils/nav_utils.py
+++ b/utils/nav_utils.py
@@ -16,7 +16,8 @@ def close_app(app):
     proceed = bool(proceed) # So it is a bool
 
     if proceed:
-        app.destroy()
+        # if you don't put the after the window close, it takes too long time to let the terminal for a new command
+        app.after(1, app.destroy())
     else:
         # You don't really need to do this
         pass


### PR DESCRIPTION
The app was waiting too long time to close, and we solve using this app.after(1,app.destroy()).